### PR TITLE
[Catalog Doc] Add CatalogInformation README

### DIFF
--- a/CatalogInformation/README.md
+++ b/CatalogInformation/README.md
@@ -1,0 +1,28 @@
+## About
+
+**Service Management** provides a DataMiner framework for managing the end-to-end life cycle of services — from design and ordering through to inventory, orchestration, and assurance. Built on **TM Forum Open APIs**, it enables organizations to standardize and automate service delivery workflows across satellite, media, telecom, and IT domains.
+
+Deploy Service Management to replace manual service tracking, eliminate coordination gaps between ordering and delivery teams, and gain real-time visibility into your live service inventory.
+
+## Key Features
+
+- **Design service specifications** — define reusable end-to-end service templates, including required components, workflows, and configuration parameters.
+- **Automate service ordering** — create and track service orders manually or via TM Forum-compatible APIs, with full lifecycle state management.
+- **Maintain a live service inventory** — view all active services, their current state, and the underlying xOps workflows or SRM bookings that deliver them.
+- **Integrate with MediaOps** — use MediaOps as the reservation and orchestration layer for service item components within each service.
+- **Support multi-domain use cases** — cover satellite, media & broadcast, telecom, and IT service types from a single unified framework.
+
+## Use Cases
+
+- **A broadcast operator** uses Service Management to define satellite uplink service specifications once and then fulfil recurring event-based orders automatically via TM Forum APIs, reducing manual handoffs between sales, engineering, and operations.
+- **A telecommunications provider** tracks the full lifecycle of fixed-line service orders — from customer request through activation and assurance — with real-time status updates reflected in the Service Inventory.
+- **An IT operations team** manages software and infrastructure service requests end-to-end using the Service Ordering Portal, ensuring every request is linked to a specification, tracked through delivery, and recorded in inventory.
+
+## Prerequisites
+
+- **MediaOps** version 1.2.3 or higher — deployable directly from the [DataMiner Catalog](https://catalog.dataminer.services/details/1b67a623-4ca6-4d25-8b3d-ed4e39496a75)
+- **DataMiner version**: *(manual action required — add both Feature Release and Main Release version numbers here)*
+
+## Technical Reference
+
+For detailed documentation, integration guides, and API specifications, refer to the [DataMiner documentation](https://docs.dataminer.services).


### PR DESCRIPTION
## Summary
- create `CatalogInformation/README.md` to resolve the catalog documentation validation error
- add a Catalog README with About, Key Features, Use Cases, Prerequisites, and Technical Reference sections
- keep the DataMiner version placeholder for manual completion by the team

## Related
- Closes #66

## Manual follow-up
- Fill in the minimum **DataMiner version** for both **Feature Release** and **Main Release** tracks in the Prerequisites section.
- Up to **3 visuals** can be added under `CatalogInformation/Images/` and referenced from the README if the team wants to enrich the Catalog page.