### PR TITLE
chore: migrate wrapper to call Master Workflow.yml directly

### DIFF
--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -18,16 +18,10 @@ on:
 jobs:
 
   CI:
-    uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/DataMiner App Packages Master Workflow.yml@main
+    uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/Master Workflow.yml@main
     with:
       configuration: Release
-      referenceName: ${{ github.ref_name }}
-      runNumber: ${{ github.run_number }}
-      referenceType: ${{ github.ref_type }}
-      repository: ${{ github.repository }}
-      owner: ${{ github.repository_owner }}
-      sonarCloudProjectName: ${{ vars.SONAR_NAME }} # Go to 'https://sonarcloud.io/projects/create' and create a project. Then create a SONAR_NAME variable with the ID of the project as mentioned in the SonarCloud project URL.
+      sonarcloud-project-name: ${{ vars.SONAR_NAME }} # Go to 'https://sonarcloud.io/projects/create' and create a project. Then create a SONAR_NAME variable with the ID of the project as mentioned in the SonarCloud project URL.
       # solutionFilterName: "MySolutionFilter.slnf"
     secrets:
-      dataminerToken: ${{ secrets.DATAMINER_TOKEN }} # The API key: generated in the DCP Admin app (https://admin.dataminer.services/) as authentication for a certain DataMiner System.
-      sonarCloudToken: ${{ secrets.SONAR_TOKEN }} # The API key for access to SonarCloud.
+      DATAMINER_TOKEN: ${{ secrets.DATAMINER_TOKEN }} # The API key: generated in the DCP Admin app (https://admin.dataminer.services/) as authentication for a certain DataMiner System.


### PR DESCRIPTION
This PR was opened automatically by the
**Wrapper Migration Workflow** in
`SkylineCommunications/_ReusableWorkflows`.

### What changed

The wrapper workflow file(s) in `.github/workflows/` were
updated to call
`SkylineCommunications/_ReusableWorkflows/.github/workflows/Master Workflow.yml`
directly instead of the legacy
**app-packages** master wrapper. Input and
secret names were renamed to the kebab-case / SHOUTING_CASE
names that `Master Workflow.yml` expects, and any obsolete
passthrough inputs (`referenceName`, `runNumber`,
`referenceType`, `repository`, `owner`, …) were dropped.

### Why

The legacy `NuGet Solution`, `Internal NuGet Solution` and
`DataMiner App Packages` master workflows are thin wrappers
that internally call `Master Workflow.yml`. Removing the
indirection:

- shortens the CI call chain by one job;
- exposes the full set of `Master Workflow.yml` inputs
  (e.g. `runs-on`) without us having to forward each one
  through every wrapper;
- lets us evolve the master inputs without breaking
  callers.

### Review checklist

- [ ] The rewrite preserves all `with:` values that were
      previously passed through (only the keys were
      renamed).
- [ ] All `secrets:` mappings are intact.
- [ ] If your wrapper job had extra steps or conditions
      around the legacy `uses:` call, verify they still
      make sense pointing at the master workflow.
- [ ] CI on this PR is green.

*Idempotent: re-running the legacy wrapper while this PR
is open will not create another one.*